### PR TITLE
Update index.md

### DIFF
--- a/en/abcd-installation/index.md
+++ b/en/abcd-installation/index.md
@@ -93,6 +93,7 @@ Be careful with possible other php.ini files existing, e.g. in \Windows or \PHP 
 
 The php.ini file contains a few more settings which need to be checked for ABCD to run correctly :
 -   register_globals = On (default = Off)
+-   short_open_tag= On
 -   extension_dir = "/ABCD/php/ext" (or adjust to the real path to your ABCD installation)
 -   default_charset = "iso-8859-1" (default = not active) or "utf8" if Unicode is to be used
 -   extension_dir = "/ABCD/php/ext" => defines the extensions directory


### PR DESCRIPTION
Consulting Isis users list the following error was reported. The error was resolved setting to On the short_open_tag parameter in php.ini file (line 96)

From: NARENDRA KUMAR <narendra_insdoc at yahoo.com>
Date: 12/08/2016 20:12 (GMT+01:00)
To: isis-users at iccisis.org
Subject: [Isis-users] ABCD VER 2.0b - Installation

Dear professionals,

Recently, I tried to install the Linux version of ABCD2.0b and installed properly and central module is working very well with   http://127.0.0.1:9090. In case of OPAC with  http://127.0.0.1:9090/site, it provides the following errors:

$file){ $html = $localPath['html'] . $file . ".html"; include($html); } flush(); ?> $file){ $html = $localPath['html'] . $file . ".html"; include($html); } flush(); ?> $file){ $html = $localPath['html'] . $file . ".html"; include($html); } flush(); ?> BVS Site 5.3.1 © BIREME/OPS/OMS<http://www.bireme.br/> [Valid XHTML 1.0 Transitional] <http://validator.w3.org/check?uri=http://localhost/site//site/php/index.php>  [Valid CSS] <http://jigsaw.w3.org/css-validator/validator?uri=http://localhost/site//site/php/index.php>